### PR TITLE
os.fspath with str and bytes support

### DIFF
--- a/pep-0NNN.rst
+++ b/pep-0NNN.rst
@@ -173,7 +173,7 @@ get the path representation one prefers. For a path object,
 of ``bytes`` should be assumed to be the default file system encoding, 
 then ``os.fsdecode()`` should be used. Finally, if a ``bytes`` 
 representation is desired and any strings should be encoded using the 
-default file system encoding then ``os.fsencode()`` is used.
+default file system encoding, then ``os.fsencode()`` is used.
 
 This PEP recommends using path objects when possible and falling back
 to string paths as necessary. Therefore, no function is provided for
@@ -191,7 +191,7 @@ same level of the hierarchy, but they vary in whether they promote or
 demote objects to another level. The ``pathlib.PurePath`` class can
 promote a ``str`` to a path object. The ``os.fspath()`` function can
 demote a path object to a ``str`` or ``bytes`` instance, depending
-on what ``__fspath__()`` returns
+on what ``__fspath__()`` returns.
 The ``os.fsdecode()`` function will demote a path object to
 a string or promote a ``bytes`` object to a ``str``. The
 ``os.fsencode()`` function will demote a path or string object to

--- a/pep-0NNN.rst
+++ b/pep-0NNN.rst
@@ -326,24 +326,6 @@ This is the task list for what this PEP proposes:
 Open Issues
 ===========
 
-Should os.fspath() return bytes?
---------------------------------
-
-Some have argued that ``os.fspath()`` should be configurable so that
-the user can specify what types are acceptable (e.g. an argument to
-say that bytes are acceptable instead of strings, or both types).
-Others have suggested that ``os.fspath()`` match the proposed
-semantics of ``PyOS_RawFSPath()``. Both camps argue that use of
-``os.fspath()`` will only be for a transitionary period while more
-libraries gain acceptance of path objects, and so being more flexible
-in what ``os.fspath()`` works with will help with the transition. The
-opponents to this -- which support the currently proposed semantics --
-worry that being so flexible with accepting bytes will lead to people
-not properly considering the ramifications of working with bytes,
-especially if bytes are transparently appearing in their code due to
-``os.fspath()``.
-
-
 The name and location of the protocol's ABC
 -------------------------------------------
 


### PR DESCRIPTION
As promised, the pull request for `str`- and `bytes`-supporting `os.fspath`.  Also closing the related open issue.